### PR TITLE
Automatic discounts don't work for non-public visible membership types

### DIFF
--- a/cividiscount.php
+++ b/cividiscount.php
@@ -773,7 +773,7 @@ function _get_candidate_discounts($code, $contact_id) {
       $contactMemberships = CRM_Member_BAO_Membership::getAllContactMembership($contact_id);
 
       // get all membership types ordered by weight
-      $membershipTypes = CRM_Member_BAO_MembershipType::getMembershipTypes();
+      $membershipTypes = CRM_Member_BAO_MembershipType::getMembershipTypes(FALSE);
 
       // if there are multiple memberships for a contact, then give preference to membership type order by weight.
       foreach($membershipTypes as $memTypeId => $dontCare ) {


### PR DESCRIPTION
We discovered that automatic discounts were not being applied to events when the membership type involved is set for 'admin' visibility.  The code in _get_candidate_discounts calls getMembershipTypes but only asks for public membership types, not all membership types.  This patch adds a 'FALSE' argument so that all membership types are retrieved.
