### PR TITLE
Corrects not calling crmURL in multiple templates, causing multiple issues

### DIFF
--- a/templates/CDM/Page/Discount/List.tpl
+++ b/templates/CDM/Page/Discount/List.tpl
@@ -48,7 +48,8 @@
     <tr id="CiviDiscount_Item-{$row.id}" class="{$row.class}{if NOT $row.is_active} disabled{/if}">
         <td class="crm-discount-code">{$row.code} <br /> {$row.description}</td>
         <td class="right">{if $row.amount_type eq '1'}{$row.amount} %{else}{$row.amount|crmMoney}{/if}</td>
-        <td class="right"><a href="/civicrm/cividiscount/report?id={$row.id}&reset=1">{$row.count_use}</a> / {if $row.count_max eq 0}{ts}Unlimited{/ts}{else}{$row.count_max}{/if}</td>
+        {assign var='urlParams' value="id=`$row.id`&reset=1"}
+        <td class="right"><a href="{crmURL p='civicrm/cividiscount/report' q=$urlParams}">{$row.count_use}</a> / {if $row.count_max eq 0}{ts}Unlimited{/ts}{else}{$row.count_max}{/if}</td>
         <td>{if $row.active_on neq '0000-00-00 00:00:00'}{$row.active_on|truncate:10:''|crmDate}{/if}</td>
         <td>{if $row.expire_on neq '0000-00-00 00:00:00'}{$row.expire_on|truncate:10:''|crmDate}{/if}</td>
         <td>{$row.action|replace:'xx':$row.id}</td>

--- a/templates/CDM/Page/Discount/Report.tpl
+++ b/templates/CDM/Page/Discount/Report.tpl
@@ -33,8 +33,9 @@
         <th class="label">{ts}Date{/ts}</th>
     <tr>
         {foreach from=$rows item=row}
-		    {if $row}
-            <td><a href="/civicrm/contact/view?reset=1&cid={$row.contact_id}">{$row.display_name}</a>&nbsp;&nbsp;(ID:{$row.contact_id})</td>
+        {if $row}
+            {assign var='urlParams' value="cid=`$row.contact_id`&reset=1"}
+            <td><a href="{crmURL q='civicrm/contact/view' q=$urlParams}">{$row.display_name}</a>&nbsp;&nbsp;(ID:{$row.contact_id})</td>
             <td>{$row.event_title}</td>
             <td>{$row.membership_title}</td>
             <td>{$row.used_date|crmDate}</td>

--- a/templates/CDM/Page/Discount/Usage.tpl
+++ b/templates/CDM/Page/Discount/Usage.tpl
@@ -38,7 +38,8 @@
         {foreach from=$rows item=row}
 		    {if $row}
             {if $hide_contact === NULL}
-              <td><a href="/civicrm/contact/view?reset=1&cid={$row.contact_id}">{$row.display_name}</a>&nbsp;&nbsp;(ID:{$row.contact_id})</td>
+              {assign var='urlParams' value="cid=`$row.contact_id`&reset=1"}
+              <td><a href="{crmURL p='civicrm/contact/view' q=$urlParams}">{$row.display_name}</a>&nbsp;&nbsp;(ID:{$row.contact_id})</td>
             {/if}
             <td>{$row.event_title}</td>
             <td>{$row.membership_title}</td>

--- a/templates/CDM/Page/Discount/View.tpl
+++ b/templates/CDM/Page/Discount/View.tpl
@@ -57,7 +57,8 @@
     </tr>
     <tr>
         <td class="label">{ts}Usage{/ts}</td>
-    	  <td><a href="/civicrm/cividiscount/report?id={$code_id}&reset=1">{$count_use}</a> / {if $count_max eq 0}{ts}Unlimited{/ts}{else}{$count_max}{/if}</td>
+        {assign var='urlParams' value="id=`$code_id`&reset=1"}
+    	<td><a href="{crmURL p='civicrm/cividiscount/report' q=$urlParams}">{$count_use}</a> / {if $count_max eq 0}{ts}Unlimited{/ts}{else}{$count_max}{/if}</td>
     </tr>
     <tr>
         <td class="label">{ts}Start Date{/ts}</td>


### PR DESCRIPTION
Also, there are links to: civicrm/cividiscount/report&cid=xxxx in these templates, but this is not yet implemented (report only accepts &id=yyyy and fatals otherwise).

I know my customer is going to notice it ... so will probably delete the links if you do not plan on implementing this soon.
