### PR TITLE
Corrects: discount for an event apply to all pricesets, regadless of user preferences

### DIFF
--- a/cividiscount.php
+++ b/cividiscount.php
@@ -362,19 +362,20 @@ function cividiscount_civicrm_buildAmount($pagetype, &$form, &$amounts) {
 
       $keys = array_keys($discounts);
       $key = array_shift($keys);
-      $discounts[$key]['pricesets'] = array();
 
       // in this case discount is specified for event id or membership type id, so we need to get info of
-      // associated price set fields. For events discount is for all the fees but for memberships we need
-      // to filter at membership type level
+      // associated price set fields. For events discount we already have the list, but for memberships we
+      // need to filter at membership type level
 
       //retrieve price set field associated with this priceset
       $priceSetInfo = CDM_Utils::getPriceSetsInfo($psid);
 
       if ($pagetype == 'event') {
-        $discounts[$key]['pricesets'] = array_combine(array_keys($priceSetInfo), array_keys($priceSetInfo));
+        // Do nothing, we already have the list of discountable price set items for this event
+        // as $discounts[$key]['pricesets'] from _cividiscount_get_candidate_discounts(); above
       }
       else {
+        $discounts[$key]['pricesets'] = array();
         // filter only valid membership types that have discount
         foreach( $priceSetInfo as $pfID => $priceFieldValues ) {
           if ( !empty($priceFieldValues['membership_type_id']) &&


### PR DESCRIPTION
When creating a discount for an event, you have to select all discountable pricesets on the discount edit screen as per the help text on the screen. But on the event registration page, the discount will apply to all pricesets related to this event, ignoring what you chose on the setup screen. So there is no way to apply the discount to only selected pricesets for an event (ie. discount admission fee but not the lunch for example).

This patch seem to correct the issue, but I had trouble understanding the logic of the original code since it seemed to overwrite the selection of pricesets from the setup screen with all available pricesets for the event on purpose.
