### PR TITLE
Fixes no discount issues if priceset ID is null in cividiscount_item table.

### DIFF
--- a/cividiscount.php
+++ b/cividiscount.php
@@ -431,7 +431,8 @@ function cividiscount_civicrm_buildAmount($pagetype, &$form, &$amounts) {
         }
 
         foreach ($fee['options'] as &$option) {
-          if (CRM_Utils_Array::value($option['id'], $discount['pricesets'])) {
+          if (CRM_Utils_Array::value($option['id'], $discount['pricesets']) ||
+              CRM_Utils_Array::value($eid, $discount['events'])) {
             list($option['amount'], $option['label']) =
               _cividiscount_calc_discount($option['amount'], $option['label'], $discount, $autodiscount, $currency);
           }


### PR DESCRIPTION
#32

Any issues with this fix?
Tested and works for events on civicrm 4.3.
