### PR TITLE
Issue 167 again

### DIFF
--- a/cividiscount.php
+++ b/cividiscount.php
@@ -437,10 +437,13 @@ function cividiscount_civicrm_buildAmount($pageType, &$form, &$amounts) {
           }
         }
       }
+      if ($autodiscount) {
+        break;
+      }
     }
 
     // Display discount message if one is available
-    if ($pageType == 'event') {
+    if ($pageType == 'event' && !$autodiscount) {
       foreach ($discounts as $code => $discount) {
         if (isset($discount['events']) && array_key_exists($eid, $discount['events']) &&
           $discount['discount_msg_enabled'] && (!isset($discountApplied) || !$discountApplied) && !empty($discount['autodiscount'])) {


### PR DESCRIPTION
The foreach loop at L363 goes through all discounts, so we have to break out when we hit our autodiscount.   If the last one is our autodiscount then, a broken clock is right twice a day.  ;-)  (see workaround mentioned before.)

Also the discount message stuff at L447 stomps on the $discount object, leaving us withe the wrong $discount['id'].

