### PR TITLE
Implement 'administer CiviDiscount' permission

### DIFF
--- a/cividiscount.php
+++ b/cividiscount.php
@@ -25,15 +25,6 @@ function cividiscount_civicrm_config(&$config) {
 }
 
 /**
- * Implements hook_civicrm_perm().
- *
- * Module extensions dont implement this hook as yet, will need to add for 4.2
- */
-function cividiscount_civicrm_perm() {
-  return array('view CiviDiscount', 'administer CiviDiscount');
-}
-
-/**
  * Implements hook_civicrm_xmlMenu().
  */
 function cividiscount_civicrm_xmlMenu(&$files) {
@@ -1159,6 +1150,16 @@ function cividiscount_civicrm_navigationMenu( &$params ) {
       )
     );
   }
+  foreach (array('Events', 'Contributions') as $header) {
+    _cividiscount_civix_insert_navigation_menu($params, $header, array(
+      'label' => ts('CiviDiscount', array('domain' => 'org.civicrm.module.cividiscount')),
+      'name' => 'CiviDiscount',
+      'url' => 'civicrm/cividiscount',
+      'permission' => 'administer CiviCRM,administer CiviDiscount',
+      'operator' => 'OR',
+      'separator' => 2,
+    ));
+  }
 }
 
 /**
@@ -1176,4 +1177,10 @@ function cividiscount_civicrm_entityTypes(&$entityTypes) {
     'table' => 'cividiscount_track'
   );
 
+}
+
+function cividiscount_civicrm_permission(&$permissions) {
+  $permissions += array(
+    'administer CiviDiscount' => ts('administer CiviDiscount', array('domain' => 'org.civicrm.module.cividiscount')),
+  );
 }

--- a/templates/CRM/CiviDiscount/Page/View.tpl
+++ b/templates/CRM/CiviDiscount/Page/View.tpl
@@ -29,12 +29,12 @@
 
   <div class="action-link">
     <div class="crm-submit-buttons">
-      {if call_user_func(array('CRM_Core_Permission','check'), 'administer CiviCRM')}
+      {if call_user_func(array('CRM_Core_Permission','check'), 'administer CiviCRM') OR call_user_func(array('CRM_Core_Permission','check'), 'administer CiviDiscount')}
         <a class="button" href='{crmURL p='civicrm/cividiscount/discount/edit' q="reset=1&id=$id"}' accesskey="e">
           <span><span class="icon ui-icon-pencil"></span>{ts}Edit{/ts}</span>
         </a>
       {/if}
-      {if call_user_func(array('CRM_Core_Permission','check'), 'delete in CiviContribute')}
+      {if call_user_func(array('CRM_Core_Permission','check'), 'delete in CiviContribute') OR call_user_func(array('CRM_Core_Permission','check'), 'administer CiviDiscount')}
         <a class="button" href='{crmURL p='civicrm/cividiscount/discount/delete' q="reset=1&id=$id"}'>
           <span><span class="icon delete-icon"></span>{ts}Delete{/ts}</span>
         </a>
@@ -121,11 +121,11 @@
   <div class="action-link">
     <div class="crm-submit-buttons">
       {assign var='urlParams' value="reset=1&id=$id"}
-      {if call_user_func(array('CRM_Core_Permission','check'), 'administer CiviCRM')}
+      {if call_user_func(array('CRM_Core_Permission','check'), 'administer CiviCRM') OR call_user_func(array('CRM_Core_Permission','check'), 'administer CiviDiscount')}
         <a class="button" href="{crmURL p='civicrm/cividiscount/discount/edit' q=$urlParams}" accesskey="e">
           <span><span class="icon ui-icon-pencil"></span>{ts}Edit{/ts}</span></a>
       {/if}
-      {if call_user_func(array('CRM_Core_Permission','check'), 'delete in CiviContribute')}
+      {if call_user_func(array('CRM_Core_Permission','check'), 'delete in CiviContribute') OR call_user_func(array('CRM_Core_Permission','check'), 'administer CiviDiscount')}
         <a class="button" href="{crmURL p='civicrm/cividiscount/discount/delete' q=$urlParams}">
           <span><span class="icon delete-icon"></span>{ts}Delete{/ts}</span></a>
       {/if}

--- a/xml/Menu/cividiscount.xml
+++ b/xml/Menu/cividiscount.xml
@@ -4,52 +4,52 @@
   <item>
      <path>civicrm/cividiscount</path>
      <page_callback>CRM_CiviDiscount_Page_List</page_callback>
-     <access_arguments>administer CiviCRM</access_arguments>
+     <access_arguments>administer CiviCRM;administer CiviDiscount</access_arguments>
      <title>Discounts</title>
   </item>
   <item>
      <path>civicrm/cividiscount/discount/add</path>
      <page_callback>CRM_CiviDiscount_Form_Admin</page_callback>
      <page_arguments>mode=1</page_arguments>
-     <access_arguments>administer CiviCRM</access_arguments>
+     <access_arguments>administer CiviCRM;administer CiviDiscount</access_arguments>
   </item>
   <item>
      <path>civicrm/cividiscount/discount/edit</path>
      <page_callback>CRM_CiviDiscount_Form_Admin</page_callback>
      <page_arguments>mode=2</page_arguments>
-     <access_arguments>administer CiviCRM</access_arguments>
+     <access_arguments>administer CiviCRM;administer CiviDiscount</access_arguments>
   </item>
   <item>
      <path>civicrm/cividiscount/discount/delete</path>
      <page_callback>CRM_CiviDiscount_Form_Admin</page_callback>
      <page_arguments>mode=8</page_arguments>
-     <access_arguments>administer CiviCRM</access_arguments>
+     <access_arguments>administer CiviCRM;administer CiviDiscount</access_arguments>
   </item>
   <item>
      <path>civicrm/cividiscount/discount/copy</path>
      <page_callback>CRM_CiviDiscount_Form_Admin</page_callback>
      <page_arguments>mode=16384</page_arguments>
-     <access_arguments>administer CiviCRM</access_arguments>
+     <access_arguments>administer CiviCRM;administer CiviDiscount</access_arguments>
   </item>
   <item>
      <path>civicrm/cividiscount/discount/view</path>
      <page_arguments>mode=4</page_arguments>
      <page_callback>CRM_CiviDiscount_Page_View</page_callback>
-     <access_arguments>administer CiviCRM</access_arguments>
+     <access_arguments>administer CiviCRM;administer CiviDiscount</access_arguments>
   </item>
   <item>
      <path>civicrm/cividiscount/settings</path>
      <page_callback>CRM_CiviDiscount_Form_Settings</page_callback>
-     <access_arguments>administer CiviCRM</access_arguments>
+     <access_arguments>administer CiviCRM;administer CiviDiscount</access_arguments>
   </item>
   <item>
      <path>civicrm/cividiscount/report</path>
      <page_callback>CRM_CiviDiscount_Page_Report</page_callback>
-     <access_arguments>administer CiviCRM</access_arguments>
+     <access_arguments>administer CiviCRM;administer CiviDiscount</access_arguments>
   </item>
   <item>
      <path>civicrm/cividiscount/usage</path>
      <page_callback>CRM_CiviDiscount_Page_Usage</page_callback>
-     <access_arguments>administer CiviCRM</access_arguments>
+     <access_arguments>administer CiviCRM;administer CiviDiscount</access_arguments>
   </item>
 </menu>


### PR DESCRIPTION
There's a stub from pre-Civi 4.2 expressing the intent to add an 'administer CiviDiscount' permission.  This PR implements that permission, so you don't have to grant "administer CiviCRM" to work with discounts.  Existing installs will be unchanged, since "administer CiviCRM" will still get you all the access it used to.

I also added CiviDiscount to the Events and Contributions menus since the Administer menu requires "administer CiviCRM".  I also removed the old stub, since it referenced the incorrect name for the hook that was eventually created.