### PR TITLE
Issue #238 Membership Discount not applied.

### DIFF
--- a/cividiscount.php
+++ b/cividiscount.php
@@ -600,6 +600,8 @@ function cividiscount_civicrm_membershipTypeValues(&$form, &$membershipTypeValue
     'autodiscount' => $discountCalculator->isAutoDiscount(),
     'contact_id' => $contact_id,
   ));
+  // unset total amount text field value submitted with form
+  unset($form->_submitValues['total_amount']);
 }
 
 /**


### PR DESCRIPTION
Overview
----------------------------------------
[GitLab Issue #238](https://lab.civicrm.org/dev/core/issues/238)

Before
----------------------------------------
1. Create a discount for membership
2. Go to Membership > New Membership
3. Select contact and set membership type to that used in 1.
4. Note the amount under the Membership Payment and Receipt section
5. Enter the discount code and Apply
6. Note that membership type changes to eg "General (Includes applied discount code SummerSpecial: 25%)" but the Amount is unchanged

Observed on dmaster.demo (5.5.alpha1) and 5.2.1

After
----------------------------------------
Discount is applied and changed in Amount text field.

Technical Details
----------------------------------------
Unset submitted form value 'total_amount' in membershipTypeValues hook.
