### PR TITLE
Alter supported versions so future releases only support 5.3+

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -21,9 +21,7 @@
   <releaseDate>2018-07-30</releaseDate>
   <version>3.5</version>
   <compatibility>
-    <ver>4.6</ver>
-    <ver>4.7</ver>
-    <ver>5.0</ver>
+    <ver>5.3</ver>
   </compatibility>
   <comments>
     For support, please ask on chat.civicrm.org


### PR DESCRIPTION
We now have a situation where 
a) 4.6 is in it's last few months as an LTS and for those using it there are already several CiviDiscount releases so we don't need to release more 4.6 compatibile releases and 
b) 4.7 through to 5.2 are insecure

So it makes sense for the next drop of CiviDiscount to support 5.3+. This won't affect existing releases but it gets us past the issue where we have an issue in the PR queue where the right function to use is not in older versions & where we have another PR which we realistically only want to have to test on the latest

@colemanw what do you think - per comments above this won't affect existing releases so it does not diminish what is available for users of earlier releases but it simplifies CiviDiscount mtce going forwards