### PR TITLE
Apply autodiscount if multiple code satisfies the auto discount condi…

### DIFF
--- a/cividiscount.php
+++ b/cividiscount.php
@@ -435,7 +435,7 @@ function cividiscount_civicrm_buildAmount($pageType, &$form, &$amounts) {
           }
         }
       }
-      if ($autodiscount) {
+      if ($autodiscount && $discountApplied) {
         break;
       }
     }


### PR DESCRIPTION
…tion

Changes included in this PR fixes the following usecase -

1. Consider the below two discount codes which are applied to different price options but to the same event types.

- eventmem20: $20 off for members discount is applied to event type `Fundraiser` and to price field options $80, $100, etc.

- eventmem35: $35 off for members discount is applied to event type `Fundraiser` and to price field options $165, $400, etc.

2. The first price field $80, $100 is used in EventA and the second ($165, $400) is used in EventB.

3. When the registration page is loaded for EventA - the auto discount for `eventmem20` is applied correctly.

4. When the registration page is loaded for EventB - the discount `eventmem35` is not applied automatically.

CiviDiscount only grabs the first discount instance for the event type.