### PR TITLE
remove display of discount code, especially needed if only auto-applied by membership

### DIFF
--- a/cividiscount.php
+++ b/cividiscount.php
@@ -890,7 +890,7 @@ function _cividiscount_filter_membership_discounts($discounts, $membershipTypeVa
  * Calculate either a monetary or percentage discount.
  */
 function _cividiscount_calc_discount($amount, $label, $discount, $autodiscount, $currency = 'USD') {
-  $title = $autodiscount ? E::ts('Includes automatic member discount of') : E::ts('Includes applied discount code %1', [1 => $discount['code']]);
+  $title = $autodiscount ? E::ts('Includes automatic member discount of') : E::ts('Includes applied discount');
   if ($discount['amount_type'] == '2') {
     $newamount = CRM_Utils_Rule::cleanMoney($amount) - CRM_Utils_Rule::cleanMoney($discount['amount']);
     $fmt_discount = CRM_Utils_Money::format($discount['amount'], $currency);


### PR DESCRIPTION
We do not need to show the discount code itself, just the description.  It is is actually counterproductive to show the discount code for auto-applied discounts based on membership that should NOT otherwise be shared.