### PR TITLE
Fix for #214: Multiple autodiscounts only applies first discount.

### DIFF
--- a/cividiscount.php
+++ b/cividiscount.php
@@ -434,12 +434,6 @@ function cividiscount_civicrm_buildAmount($pageType, &$form, &$amounts) {
           }
         }
       }
-      /*
-      // #214
-      if ($autodiscount) {
-        break;
-      }
-      */
     }
 
     // Display discount message if one is available

--- a/cividiscount.php
+++ b/cividiscount.php
@@ -434,9 +434,12 @@ function cividiscount_civicrm_buildAmount($pageType, &$form, &$amounts) {
           }
         }
       }
+      /*
+      // #214
       if ($autodiscount) {
         break;
       }
+      */
     }
 
     // Display discount message if one is available


### PR DESCRIPTION
I commented out: 'break;' so that the script loops all the auto discounts and uses the discount with the highest value.