### PR TITLE
Control Discount on New or Existing Membership

### DIFF
--- a/CRM/CiviDiscount/BAO/Item.php
+++ b/CRM/CiviDiscount/BAO/Item.php
@@ -51,6 +51,9 @@ class CRM_CiviDiscount_BAO_Item extends CRM_CiviDiscount_DAO_Item {
       $item->active_on = 'null';
     }
 
+    $item->membership_new = CRM_Utils_Array::value('membership_new', $params) ? 1 : 0;
+    $item->membership_renew = CRM_Utils_Array::value('membership_renew', $params) ? 1 : 0;
+
     if (!empty($params['expire_on'])) {
       $item->expire_on = CRM_Utils_Date::processDate($params['expire_on']);
     }
@@ -124,7 +127,7 @@ class CRM_CiviDiscount_BAO_Item extends CRM_CiviDiscount_DAO_Item {
     discount_msg,
     count_use,
     count_max,
-    filters
+    filters, membership_new, membership_renew
   FROM cividiscount_item AS i
   WHERE is_active = 1
   AND (active_on IS NULL OR active_on <= NOW())

--- a/CRM/CiviDiscount/DAO/Item.php
+++ b/CRM/CiviDiscount/DAO/Item.php
@@ -173,6 +173,18 @@ class CRM_CiviDiscount_DAO_Item extends CRM_Core_DAO {
    */
   public $is_active;
   /**
+   * Is discount code applicable for New Members applicant?
+   *
+   * @var boolean
+   */
+  public $membership_new;
+  /**
+   * Is discount code applicable for Existing Members applicant?
+   *
+   * @var boolean
+   */
+  public $membership_renew;
+  /**
    * Is there a message to users not eligible for a discount?
    *
    * @var boolean
@@ -326,6 +338,14 @@ class CRM_CiviDiscount_DAO_Item extends CRM_Core_DAO {
           'title' => E::ts('Discount Message'),
           'maxlength' => 255,
           'size' => CRM_Utils_Type::HUGE,
+        ],
+        'membership_new' => [
+          'name' => 'membership_new',
+          'type' => CRM_Utils_Type::T_BOOLEAN,
+        ],
+        'membership_renew' => [
+          'name' => 'membership_renew',
+          'type' => CRM_Utils_Type::T_BOOLEAN,
         ],
       ];
     }

--- a/CRM/CiviDiscount/Form/Admin.php
+++ b/CRM/CiviDiscount/Form/Admin.php
@@ -172,6 +172,9 @@ class CRM_CiviDiscount_Form_Admin extends CRM_Admin_Form {
         FALSE,
         $this->select2style
       );
+
+      $this->addElement('checkbox', 'membership_new', E::ts('New members during application?'));
+      $this->addElement('checkbox', 'membership_renew', E::ts('Renewing members ?'));
     }
     $this->assignAutoDiscountFields();
     $this->addElement('text', 'advanced_autodiscount_filter_entity', E::ts('Specify entity for advanced autodiscount'));

--- a/CRM/CiviDiscount/Upgrader.php
+++ b/CRM/CiviDiscount/Upgrader.php
@@ -50,4 +50,16 @@ class CRM_CiviDiscount_Upgrader extends CRM_CiviDiscount_Upgrader_Base {
     return TRUE;
   }
 
+  public function upgrade_3701() {
+    if (CRM_Core_BAO_SchemaHandler::checkIfFieldExists('cividiscount_item', 'membership_new')) {
+      $this->ctx->log->info('Skipped cividiscount update 3701.  Column membership_new already present on cividiscount_item table.');
+    }
+    else {
+      $this->ctx->log->info('Applying cividiscount update 3701.  Adding membership_new, membership_renew to the cividiscount_item table.');
+      CRM_Core_DAO::executeQuery('ALTER TABLE cividiscount_item ADD COLUMN membership_new TINYINT(1) DEFAULT 0 COMMENT "Discount for New members applicant.?" AFTER filters');
+      CRM_Core_DAO::executeQuery('ALTER TABLE cividiscount_item ADD COLUMN membership_renew TINYINT(1) DEFAULT 0 COMMENT "Discount for Renewing members applicant.?" AFTER membership_new');
+    }
+    return TRUE;
+  }
+
 }

--- a/sql/auto_install.sql
+++ b/sql/auto_install.sql
@@ -27,7 +27,8 @@ CREATE TABLE `cividiscount_item` (
      `discount_msg_enabled` tinyint DEFAULT 0 COMMENT 'Is discount message is available for promotion?',
      `discount_msg` VARCHAR(255) COMMENT 'Discount message',
      `filters` varchar(255) COMMENT 'Discount Filters.',
-
+     `membership_new` tinyint(1) DEFAULT 0 COMMENT 'Discount for New members applicant.?',
+     `membership_renew` tinyint(1) DEFAULT 0 COMMENT 'Discount for Renewing members applicant.?',
     PRIMARY KEY ( `id` ),
      CONSTRAINT FK_cividiscount_item_organization_id FOREIGN KEY (`organization_id`) REFERENCES `civicrm_contact`(`id`) ON DELETE SET NULL
 ) ENGINE=InnoDB DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci;

--- a/templates/CRM/CiviDiscount/Form/Admin.hlp
+++ b/templates/CRM/CiviDiscount/Form/Admin.hlp
@@ -86,3 +86,13 @@
     {ts}Enter the message you'd like users to see if they are not receiving a discount. Can be used to promote membership.<br />The message will appear above the form.{/ts}
   </p>
 {/htxt}
+{htxt id="membership_new"}
+  <p>
+      {ts}You can control whether discount coupon applies to new memberships.{/ts}
+  </p>
+{/htxt}
+{htxt id="membership_renew"}
+  <p>
+      {ts}You can control whether discount coupon applies to membership renewals.{/ts}
+  </p>
+{/htxt}

--- a/templates/CRM/CiviDiscount/Form/Admin.tpl
+++ b/templates/CRM/CiviDiscount/Form/Admin.tpl
@@ -148,11 +148,11 @@
               <td>{$form.memberships.html}<br/></td>
             </tr>
             <tr class="crm-discount-item-form-block-membership-new">
-              <td class="label">{$form.membership_new.label}</td>
+              <td class="label">{$form.membership_new.label}  {help id="membership_new" title=$form.membership_new.label}</td>
               <td>{$form.membership_new.html}<br/></td>
             </tr>
             <tr class="crm-discount-item-form-block-membership-renew">
-              <td class="label">{$form.membership_renew.label}</td>
+              <td class="label">{$form.membership_renew.label}  {help id="membership_renew" title=$form.membership_renew.label}</td>
               <td>{$form.membership_renew.html}<br/></td>
             </tr>
           </table>

--- a/templates/CRM/CiviDiscount/Form/Admin.tpl
+++ b/templates/CRM/CiviDiscount/Form/Admin.tpl
@@ -147,6 +147,14 @@
               <td class="label">{$form.memberships.label} {help id="memberships" title=$form.memberships.label}</td>
               <td>{$form.memberships.html}<br/></td>
             </tr>
+            <tr class="crm-discount-item-form-block-membership-new">
+              <td class="label">{$form.membership_new.label}</td>
+              <td>{$form.membership_new.html}<br/></td>
+            </tr>
+            <tr class="crm-discount-item-form-block-membership-renew">
+              <td class="label">{$form.membership_renew.label}</td>
+              <td>{$form.membership_renew.html}<br/></td>
+            </tr>
           </table>
         </div>
       </div>


### PR DESCRIPTION
Before
We can not set discount for New or Renewal Member only

After
We can set discount code for New and/or Renewal member only.
<img width="914" alt="Screenshot 2019-11-17 at 11 20 05 AM" src="https://user-images.githubusercontent.com/377735/69003694-b8b06380-092c-11ea-9185-269c8cca2671.png">

Issue #230 