### PR TITLE
dev/cividiscount#5: Add Taxes to Membership Amount After Discount

### DIFF
--- a/cividiscount.php
+++ b/cividiscount.php
@@ -598,7 +598,12 @@ function cividiscount_civicrm_membershipTypeValues(&$form, &$membershipTypeValue
       // this will overwrite the submitted total amount
       if (!empty($form->_submitValues['membership_type_id'])) {
         if ($values['member_of_contact_id'] == $form->_submitValues['membership_type_id'][0] && $values['id'] == $form->_submitValues['membership_type_id'][1]) {
-          $form->_submitValues['total_amount'] = $value;
+          $taxRates = CRM_Core_PseudoConstant::getTaxRates();
+          $membershipType = $membershipType = civicrm_api3('MembershipType', 'getsingle', [
+            'id' => $values['id'],
+          ]);
+          $taxRate = CRM_Utils_Array::value($membershipType['financial_type_id'], $taxRates, 0);
+          $form->_submitValues['total_amount'] = (1 + $taxRate/100) * $value;
         }
       }
     }


### PR DESCRIPTION
## Overview
When creating a membership, if you apply the discount code after selecting the membership, the total amount will be discounted, but will fail to include taxes.

Issue tracked here: https://lab.civicrm.org/extensions/cividiscount/issues/5

## Before
If discount was applied after selecting membership type, total amount was calculated by applying the discount to original membership type minimum fee, but no taxes where added.

## After
Fixes the total amount by calculating tax and adding it, if membership type has related tax rate.
