### PR TITLE
dev#239 fix js error for attribute not exist

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -25,6 +25,7 @@ CRM.$(function($) {
     function skipPaymentMethod() {
       var flag = false;
       $('.price-set-option-content input').each( function(){
+        if (!$(this)[0].hasAttribute("data-amount")) return;
         currentTotal = $(this).attr('data-amount').replace(/[^\/\d]/g,'');
         if ($(this).is(':checked')) {
           if (currentTotal == 0 ) {


### PR DESCRIPTION
When you create Multiple price field in one price set, and one of the price field is not required, then civicrm give additional option to say `- none -`, this element does not contain `data-amount` attribute. This lead to generate JS Error.

This fix, will check `data-amount` attribute exist. if not, it return for continue next iteration.

<img width="883" alt="Screenshot 2020-08-30 at 7 15 07 PM" src="https://user-images.githubusercontent.com/377735/91660832-bdc65400-eaf5-11ea-933d-c0b700cf3368.png">

------------------------------------------
https://github.com/civicrm/org.civicrm.module.cividiscount/issues/239