### PR TITLE
Filter out empty lines from discount array

### DIFF
--- a/CRM/CiviDiscount/BAO/Item.php
+++ b/CRM/CiviDiscount/BAO/Item.php
@@ -111,7 +111,7 @@ class CRM_CiviDiscount_BAO_Item extends CRM_CiviDiscount_DAO_Item {
         $items = [];
       }
       else {
-        $items = explode(CRM_Core_DAO::VALUE_SEPARATOR, trim($discount[$field], CRM_Core_DAO::VALUE_SEPARATOR));
+        $items = array_filter(explode(CRM_Core_DAO::VALUE_SEPARATOR, trim($discount[$field], CRM_Core_DAO::VALUE_SEPARATOR)));
         if (!empty($items)) {
           if (!isset($filters[$entity])) {
             $filters[$entity] = [];


### PR DESCRIPTION
Without this array_filter the array is winding up as [0 => ''] and failing to apply the discount based on later
empty() checks

With this patch I see the discount applied after I submit
<img width="604" alt="Screen Shot 2020-09-11 at 4 37 28 PM" src="https://user-images.githubusercontent.com/336308/92861065-23e39d00-f44d-11ea-8cda-27bb751b1d7c.png">
