### PR TITLE
CPS-332: Style fix for discount apply button

### DIFF
--- a/cividiscount.php
+++ b/cividiscount.php
@@ -1055,7 +1055,16 @@ function _cividiscount_add_discount_textfield(&$form) {
   }
   $form->set('discountCodeErrorMsg', NULL);
   $buttonName = $form->getButtonName('reload');
-  $form->addElement('submit', $buttonName, E::ts('Apply'), ['formnovalidate' => 1]);
+  $form->addElement(
+    'xbutton',
+    $buttonName,
+    E::ts('Apply'),
+    [
+      'formnovalidate' => 1,
+      'type' => 'submit',
+      'class' => 'crm-form-submit',
+    ]
+  );
   $template = CRM_Core_Smarty::singleton();
   $bhfe = $template->get_template_vars('beginHookFormElements');
   if (!$bhfe) {
@@ -1115,7 +1124,16 @@ function _cividiscount_add_button_before_priceSet(&$form) {
   }
   $form->set('discountCodeErrorMsg', NULL);
   $buttonName = $form->getButtonName('reload');
-  $form->addElement('submit', $buttonName, E::ts('Apply'), ['formnovalidate' => 1]);
+  $form->addElement(
+    'xbutton',
+    $buttonName,
+    E::ts('Apply'),
+    [
+      'formnovalidate' => 1,
+      'type' => 'submit',
+      'class' => 'crm-form-submit',
+    ]
+  );
   $form->assign('discountElements', [
     'discountcode',
     $buttonName


### PR DESCRIPTION
Overview
----------------------------------------
In https://github.com/civicrm/civicrm-core/pull/18410/files#diff-6b993747c85ceec4b537726331c934f4aeac58a54152f850dab5aec2942a1009L65, the button markup was changed from `input` to `button`. This PR applies the same to Cividiscount.

Before
----------------------------------------
![2020-10-19 at 5 18 PM](https://user-images.githubusercontent.com/5058867/96447133-2f399d80-122f-11eb-96ef-9d159e206b15.png)

After
----------------------------------------
![2020-10-19 at 5 18 PM](https://user-images.githubusercontent.com/5058867/96446889-2052eb00-122f-11eb-9e0e-339ac8be2d9e.png)
