### PR TITLE
Ensure postprocess is called only once

### DIFF
--- a/cividiscount.php
+++ b/cividiscount.php
@@ -627,11 +627,13 @@ function cividiscount_civicrm_postProcess($class, &$form) {
   ])) {
     return;
   }
+  static $done = FALSE;
 
   $discountInfo = $form->get('_discountInfo');
-  if (!$discountInfo) {
+  if (!$discountInfo || $done) {
     return;
   }
+  $done = TRUE;
 
   $discount = $discountInfo['discount'];
   $params = $form->getVar('_params');


### PR DESCRIPTION
Fixes https://github.com/civicrm/org.civicrm.module.cividiscount/issues/229

We're on latest extension version and still see duplicate DiscountTrack item being recorded in the database. This can be replicated by making a membership payment with eg a dummy processor (live mode).

ensuring the postprocess is called only once, fixes the problem for us.