### PR TITLE
Make description field required on the form

### DIFF
--- a/CRM/CiviDiscount/Form/Admin.php
+++ b/CRM/CiviDiscount/Form/Admin.php
@@ -137,7 +137,7 @@ class CRM_CiviDiscount_Form_Admin extends CRM_Admin_Form {
       $element->freeze();
     }
 
-    $this->add('text', 'description', E::ts('Description'), CRM_Core_DAO::getAttribute('CRM_CiviDiscount_DAO_Item', 'description'));
+    $this->add('text', 'description', E::ts('Description'), CRM_Core_DAO::getAttribute('CRM_CiviDiscount_DAO_Item', 'description'), TRUE);
 
     $this->addMoney('amount', E::ts('Discount Amount'), TRUE, CRM_Core_DAO::getAttribute('CRM_CiviDiscount_DAO_Item', 'amount'), FALSE);
 


### PR DESCRIPTION
This field is set to required on [DAO/xml](https://github.com/civicrm/org.civicrm.module.cividiscount/blob/master/xml/schema/CRM/CiviDiscount/Item.xml#L33) but not on the form? 

If this is left as blank, it prints a null string on the main page - see https://github.com/civicrm/org.civicrm.module.cividiscount/issues/248

This also stores "null" string in the line item table which displays the same on invoices, receipt, etc.

OR is this NOT meant to be required?