### PR TITLE
fix price field options to display all options

### DIFF
--- a/CRM/CiviDiscount/Utils.php
+++ b/CRM/CiviDiscount/Utils.php
@@ -41,6 +41,10 @@ class CRM_CiviDiscount_Utils {
   public static function getNestedPriceSets() {
     $values = self::getPriceSetsInfo();
 
+    // Sort by ps_label or you'll lose any out-of-order price fields.
+    usort($values, function($a, $b) {
+      return $a['ps_label'] <=> $b['ps_label'];
+    });
     $priceSets = [];
     if (!empty($values)) {
       $currentLabel = NULL;


### PR DESCRIPTION
### Steps to replicate
* Create two price field sets, "Set 1" and "Set 2".
* In Set 1, create two price fields, "Apple" and "Carrot".
* In Set 2, create two price fields, "Banana" and "Daikon".
* Assign each price set to an active event.
* Create a new discount.
* Click on the Select2 for **Price Field Options**.

### Expected Result
![Selection_1159](https://user-images.githubusercontent.com/1796012/127060556-9d5b2b09-9dd7-4046-8aff-731beca1718d.png)

### Actual Result
![Selection_1158](https://user-images.githubusercontent.com/1796012/127060576-19c6bf0a-7af7-4058-8c2e-2b2eec940edb.png)

This happens because this Select2 is populated by a function `getNestedPriceInfo()`.  This takes a list of price fields and nests them by price set label.  However, if you have the same price set more than once, only the last one is available in the Select2.  So you must sort the price *field* labels first by price *set* info.

I considered modifying the SQL instead of sorting in PHP, but this would ruin the order for the other function that calls `getPriceSetInfo()`.